### PR TITLE
Fix case sensitive names

### DIFF
--- a/ch569_hspi2cdc/CH569_HSPI_USB/RVMSIS/core_riscv.h
+++ b/ch569_hspi2cdc/CH569_HSPI_USB/RVMSIS/core_riscv.h
@@ -17,7 +17,7 @@
 #endif
 
 #include <stdint.h>
-#include "CH56xSFR.H"
+#include "CH56xSFR.h"
 
 /* IO definitions */
 #ifdef __cplusplus

--- a/ch569_hspi2cdc/CH569_HSPI_USB/User/USB30/CH56x_usb30.c
+++ b/ch569_hspi2cdc/CH569_HSPI_USB/User/USB30/CH56x_usb30.c
@@ -9,7 +9,7 @@
 * microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #include "CH56x_common.h"
-#include "CH56x_USB30_LIB.H"
+#include "CH56x_usb30_LIB.h"
 #include "CH56x_usb20.h"
 #include "CH56x_usb30.h"
 #include "cdc.h"


### PR DESCRIPTION
Linux is case sensitive. I'm getting compilation issues when compiling under MRS 2 in Linux.